### PR TITLE
In CI, add version.txt to app

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -192,6 +192,13 @@ function build(previousFileSizes) {
         warnings: messages.warnings,
       };
 
+      // Write the SHA to the build path. We reference this in the landing page
+      // docs as an URL folks can look at if they want to find a version they can
+      // pin in their server.
+      if (process.env.CIRCLE_SHA1) {
+        fs.writeFileSync(paths.appBuild + '/version.txt', process.env.CIRCLE_SHA1 + '\n');
+      }
+
       if (writeStatsJson) {
         return bfj
           .write(paths.appBuild + '/bundle-stats.json', stats.toJson())


### PR DESCRIPTION
The landing page plugin lets you specify a specific version to pin your app to. Our docs will tell folks to look at https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt to discover the current version.