### PR TITLE
Copy tweaks for Prod Configured

### DIFF
--- a/src/content/ProdConfigured.tsx
+++ b/src/content/ProdConfigured.tsx
@@ -58,7 +58,7 @@ export default ({
               href={`${baseUrl}/graph/${graphRef}/explorer`}
             >
               query this endpoint from Apollo Studio
-            </a>
+            </a>.
           </p>
 
           <div style={{ fontSize: 13 }}>


### PR DESCRIPTION
Addresses comments on copy https://apollograph.slack.com/archives/C01SSUU20RZ/p1623281683057000

- displaying the graph ID in the header is not gonna be great for the vast sea of users whose graphs have IDs like My-Graph-j98efa  
- I don’t really get who the “you” is in “for your graph in Apollo Studio” — if this is a public API then it’s not “your” graph? Or is the idea that we would encourage people only to enable this page for non-public APIs?

Thank goodness for the CLI snippet that can continue to act as a sort of focal-point