### PR TITLE
Don't redirect to Sandbox if isProd

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export default () => {
 
   if (isProd && !!graphRef && getCookieValue(prodRedirectCookie) === 'true') {
     window.location.replace(`${baseUrl}/graph/${graphRef}/explorer`);
-  } else if (getCookieValue(localRedirectCookie) === 'true') {
+  } else if (!isProd && getCookieValue(localRedirectCookie) === 'true') {
     window.location.replace(
       `${baseUrl}/sandbox?endpoint=${encodeURIComponent(window.location.href)}`,
     );


### PR DESCRIPTION
You may well have the local cookie set from a previous run of some server in local mode, but if we're in prod mode on the same URL we should never redirect to Sandbox.