### PR TITLE
CLIQueryInstructions: remove extra single quotes

### DIFF
--- a/src/components/CLIQueryInstructions.tsx
+++ b/src/components/CLIQueryInstructions.tsx
@@ -30,7 +30,7 @@ const CLIQueryInstructions = ({ endpoint }: { endpoint: string }) => (
       {[
         `curl --request POST \\`,
         `  --header 'content-type: application/json' \\`,
-        `  --url '${escapeShellArgument(endpoint)}' \\`,
+        `  --url ${escapeShellArgument(endpoint)} \\`,
         `  --data '${JSON.stringify({
           query: 'query { __typename }',
         })}'`,


### PR DESCRIPTION
escapeShellArgument already adds quotes when needed, so this served to
unescape!